### PR TITLE
feat/issuers

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,12 +181,12 @@ def watch_crd(group, version, plural, use_local_config=False):
                 elif t == 'DELETED':
                     if not secretname and PATCH_SECRETNAME:
                         secretname = name
-                    
+
                     if secretname:
                         delete_certificate(crds, namespace, secretname)
                     else:
                         logging.info(f"{namespace}/{name} : no secretName found in IngressRoute, skipping delete")
-                    
+
                 else:
                     logging.info(f"{namespace}/{name} : unknown event type: {t}")
                     logging.debug(json.dumps(obj, indent=2))
@@ -243,7 +243,7 @@ def main():
     if SUPPORT_LEGACY_CRDS:
         # deprecated traefik CRD
         th2 = threading.Thread(
-            target=watch_crd, 
+            target=watch_crd,
             args=(
                 "traefik.containo.us",
                 "v1alpha1",

--- a/main.py
+++ b/main.py
@@ -46,6 +46,13 @@ def create_certificate(crds, namespace, secretname, routes, cls, annotations):
         logging.info(f"Ignoring {namespace}/{secretname} (ignore=true)")
         return
 
+    try:
+        assert crds.get_namespaced_custom_object(CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, secretname)
+        logging.info(f"{secretname} : certificate request already exists.")
+        return
+    except ApiException:
+        pass
+
     # Determine issuerRef priority
     if 'cert-manager.io/cluster-issuer' in annotations:
         issuer_kind = 'ClusterIssuer'
@@ -85,10 +92,7 @@ def create_certificate(crds, namespace, secretname, routes, cls, annotations):
             },
         }
         try:
-            crds.get_namespaced_custom_object(
-                CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, secretname
-            )
-            crds.patch_namespaced_custom_object(
+            crds.create_namespaced_custom_object(
                 CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, body
             )
         except ApiException as e:


### PR DESCRIPTION
Implement mutiple/issuers

- Filter by `kubernetes.io/ingress.class`
- ignore `ingressroute` if annotation `cert-manager.io/ignore` is present
- configure filter set with `FILTER_SET` comma seperated
- regenerate if annotations change
- ignore if no tls.secretName
- configure issuer with `cert-manager.io/cluster-issuer` annotation on ingressroute
- configure out-of-tree with
  - `cert-manager.io/issuer-kind` annotation on ingressroute
  - `cert-manager.io/issuer` annotation on ingressroute
- use fallback if no annotation are set and we need to process the ingressroute